### PR TITLE
Remove automatic mounting of home directory

### DIFF
--- a/plugins/lando-core/compose/lando/builder.js
+++ b/plugins/lando-core/compose/lando/builder.js
@@ -92,9 +92,6 @@ module.exports = {
         if (sslExpose) ports.push(sport);
       }
 
-      // Add in some more dirz if it makes sense
-      if (home) volumes.push(`${home}:/user:cached`);
-
       // Handle cert refresh
       // @TODO: this might only be relevant to the proxy, if so let's move it there
       if (refreshCerts) volumes.push(`${refreshCertsScript}:/scripts/999-refresh-certs`);


### PR DESCRIPTION
This is a security issue since all SSH-keys are made available for the containers and in most projects not even a necessary volume.

The mounting of the home directory also triggers a [docker bug](https://github.com/docker/for-mac/issues/5164#issuecomment-857760561) that makes docker use 100% cpu on the mac.