### PR TITLE
Added support for go version 1.15 and 1.16

### DIFF
--- a/examples/go/.lando.yml
+++ b/examples/go/.lando.yml
@@ -4,7 +4,7 @@ services:
     type: go
     command: go run /app/http.go
   patch:
-    type: go:1.13.9
+    type: go:1.16.5
   custom:
     type: go
     ssl: true

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -23,14 +23,14 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should use 1.14 as the default version
-lando ssh -s defaults -c "go version | grep go1.14"
+lando ssh -s defaults -c "go version | grep go1.16"
 
 # Should run only on port 80 by default
 lando ssh -s defaults -c "curl http://localhost" | grep HEART
 lando ssh -s defaults -c "curl https://localhost" || echo $? | grep 1
 
 # Should use the version if specified by user
-lando ssh -s patch -c "go version | grep go1.13.9"
+lando ssh -s patch -c "go version | grep go1.16.5"
 
 # Should serve over http and https if ssl is set by user
 lando ssh -s custom -c "curl http://localhost" | grep HEART

--- a/plugins/lando-services/services/go/builder.js
+++ b/plugins/lando-services/services/go/builder.js
@@ -7,8 +7,8 @@ const _ = require('lodash');
 module.exports = {
   name: 'go',
   config: {
-    version: '1.14',
-    supported: ['1.14', '1.13'],
+    version: '1.16',
+    supported: ['1.16', '1.15', '1.14', '1.13'],
     patchesSupported: true,
     legacy: ['1.12', '1.11', '1.10', '1.9', '1.8'],
     command: 'tail -f /dev/null',


### PR DESCRIPTION
We need to keep up nearing another 1.5 year mark. There is no danger in updating. If we can push some more versions to legacy please let me know.