### PR TITLE
Add missing folders in $PATH for P.sh containers

### DIFF
--- a/integrations/lando-platformsh/types/platformsh-appserver/builder.js
+++ b/integrations/lando-platformsh/types/platformsh-appserver/builder.js
@@ -18,7 +18,7 @@ const LANDO_PATH = [
   '/app/vendor/bin',
   '/app/bin',
   '/app/.global/bin',
-  '/app/.global/vendor/bin'
+  '/app/.global/vendor/bin',
   '/usr/local/sbin',
   '/usr/local/bin',
   '/usr/sbin',

--- a/integrations/lando-platformsh/types/platformsh-appserver/builder.js
+++ b/integrations/lando-platformsh/types/platformsh-appserver/builder.js
@@ -17,6 +17,8 @@ const LANDO_PATH = [
   '/var/www/.composer/vendor/bin',
   '/app/vendor/bin',
   '/app/bin',
+  '/app/.global/bin',
+  '/app/.global/vendor/bin'
   '/usr/local/sbin',
   '/usr/local/bin',
   '/usr/sbin',


### PR DESCRIPTION
Some build/deploy scripts rely on the `/app/.global` directory, like the [Symfony configurator](https://github.com/symfonycorp/platformsh-symfony-template/blob/main/.platform.app.yaml#L42).

This PR adds the missing folders in `$PATH`.