### PR TITLE
Files containing 'PRIVATE KEY' should be added to SSH_KEYS & SSH_IDEN…

### DIFF
--- a/plugins/lando-core/scripts/load-keys.sh
+++ b/plugins/lando-core/scripts/load-keys.sh
@@ -100,10 +100,10 @@ for SSH_CANDIDATE in "${SSH_CANDIDATES[@]}"; do
         SSH_KEYS+=("$SSH_CANDIDATE")
         SSH_IDENTITIES+=("  IdentityFile \"$SSH_CANDIDATE\"")
       fi
-    else
-      SSH_KEYS+=($SSH_CANDIDATE)
-      SSH_IDENTITIES+=("  IdentityFile \"$SSH_CANDIDATE\"")
     fi
+  else
+    SSH_KEYS+=($SSH_CANDIDATE)
+    SSH_IDENTITIES+=("  IdentityFile \"$SSH_CANDIDATE\"")
   fi
 done
 


### PR DESCRIPTION
Fix for #34

Files that contain `PRIVATE KEY` should be added to the `SSH_KEYS` and `SSH_IDENTITIES` arrays. 

Without a change somewhere here, there is no way to load keys generated for plugins like lagoon
`/lando/keys/lagoon-UUID-HASH`