### PR TITLE
Add support for mongodb 4.4 and 5.0

### DIFF
--- a/plugins/lando-services/services/mongo/builder.js
+++ b/plugins/lando-services/services/mongo/builder.js
@@ -8,9 +8,11 @@ module.exports = {
   name: 'mongo',
   config: {
     version: '4.2',
-    supported: ['4.2', '4.1', '4.0', '3.6'],
+    supported: ['5.0', '4.4', '4.2', '4.1', '4.0', '3.6'],
     legacy: ['4.1'],
     pinPairs: {
+      '5.0': 'bitnami/mongodb:5.0.3-debian-10-r8',
+      '4.4': 'bitnami/mongodb:4.4.9-debian-10-r10',
       '4.2': 'bitnami/mongodb:4.2.6-debian-10-r33',
       '4.1': 'bitnami/mongodb:4.1.13-debian-9-r96',
       '4.0': 'bitnami/mongodb:4.0.13-debian-9-r45',


### PR DESCRIPTION
If you have a current project with 4.2, you need to upgrade to 4.4 *first* (lando rebuild) and do the tiny step described here: 
https://docs.mongodb.com/v5.0/release-notes/4.4-upgrade-standalone/

> Run the setFeatureCompatibilityVersion command against the admin database:
`db.adminCommand( { setFeatureCompatibilityVersion: "4.4" } )`

Before upgrading to 5.0. Is this something I should add to the CHANGELOG.md? 
