### PR TITLE
Remove forced `xdebug: false` setting from Acquia recipe

### DIFF
--- a/integrations/lando-acquia/recipes/acquia/builder.js
+++ b/integrations/lando-acquia/recipes/acquia/builder.js
@@ -29,7 +29,6 @@ module.exports = {
       // Load .env file.
       options.env_file = ['.env'];
       options.webroot = 'docroot';
-      options.xdebug = false;
 
       // Get and discover our keys
       const keys = utils.sortKeys(options._app.acquiaKeys, options._app.hostKeys);


### PR DESCRIPTION
This config keeps xdebug disabled and does not allow for overrides from a project's `.lando.yml` config.

Fixes https://github.com/lando/lando/issues/3155