### PR TITLE
uselagoon SOLR unable to restart due to uid:gid

### DIFF
--- a/integrations/lando-lagoon/services/lagoon-solr/builder.js
+++ b/integrations/lando-lagoon/services/lagoon-solr/builder.js
@@ -27,6 +27,10 @@ module.exports = {
       if (_.get(options, '_app._config.uid', '1000') !== '1001') options._app.nonRoot.push(options.name);
 
       const solr = {
+        environment: _.merge({}, options.environment, {
+          LANDO_HOST_UID: 8983,
+          LANDO_HOST_GID: 8983,
+        }),
         command: options.command,
         ports: [options.port],
         volumes: [


### PR DESCRIPTION
Interesting behaviour observed with Lagoon recipe and uselagoon/solr image.

LANDO_WEBROOT_UID & LANDO_WEBROOT_GID isnt explicitly set, resulting in the following:

`lando start`
solr builds fine

`lando stop`
`lando start`
...solr wont start

Error is a permission denied on a touch of /tmp/ready

The touch is coming down from the uselagoon/commons docker
https://github.com/uselagoon/lagoon-images/blob/main/images/commons/lagoon/entrypoints/999-readiness.sh#L5

What I'm observing I believe is:
1. First install solr user is 8983:8983 before lando gets on-top.
2. Second start, solr user has had uid/gid changed and is now 501:20
3. Entrypoint script runs, trys to touch a file thats already there on restart, permission denied.

cat of /etc/passwd:
`solr:x:501:20:Linux User,,,:/var/www:/bin/ash`

Intermediate fix?
Setting the env directly in docker-compose, dockerfile or lando overrides fixes the issue:

LANDO_HOST_UID: 8983
LANDO_HOST_GID: 8983

cat of /etc/passwd:
`solr:x:8983:1000:Linux User,,,:/var/www:/bin/ash`

gid is 1000 for some reason?, but uid is correct, so at least it all seems to work.

This PR?
Add the gid and uid.
I reckon this change is minimal enough to not negatively impact, and [does what the root plugin does](https://github.com/lando/cli/blob/53eaddc11ce44fe3b38708f4ac3d5275b2c931c4/plugins/lando-services/services/solr/builder.js#L89-L99).

I'm not convinced this is isolated to just uselagoon/solr either, if you set your user to solr in dockerfile, and dont set the correct lando uid:gid - its going to do some weird stuff?!