### PR TITLE
lando/lando#3211: Standardize on the --service argument for all tooli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v3.5.2 - [2021](https://github.com/lando/cli/releases/tag/v3.5.2)
+
+Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).
+
+### Core
+
+* Standardize on the --service argument for DB commands [#3211](https://github.com/lando/lando/issues/3211)
+
 ## v3.5.1 - [October 29, 2021](https://github.com/lando/cli/releases/tag/v3.5.1)
 
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).

--- a/plugins/lando-recipes/lib/utils.js
+++ b/plugins/lando-recipes/lib/utils.js
@@ -13,7 +13,7 @@ const mysqlCli = {
     host: {
       description: 'The database service to use',
       default: 'database',
-      alias: ['h'],
+      alias: ['h', 's', 'service'],
     },
   },
 };

--- a/plugins/lando-recipes/types/laemp/builder.js
+++ b/plugins/lando-recipes/types/laemp/builder.js
@@ -20,7 +20,7 @@ const toolingDefaults = {
       'host': {
         description: 'The database service to use',
         default: 'database',
-        alias: ['h'],
+        alias: ['h', 's', 'service'],
       },
       'no-wipe': {
         description: 'Do not destroy the existing database before an import',
@@ -37,7 +37,7 @@ const toolingDefaults = {
       host: {
         description: 'The database service to use',
         default: 'database',
-        alias: ['h'],
+        alias: ['h', 's', 'service'],
       },
       stdout: {
         description: 'Dump database to stdout',


### PR DESCRIPTION
…ng that can target a service.

Works for the core LAEMP `mysql`, `db-import`, and `db-export` commands. Will add a similar option to [the PR for the Pantheon recipe](https://github.com/lando/pantheon/pull/4) since it implements a variant on the `mysql` tooling.