### PR TITLE
Adds debug log on scan result

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -61,7 +61,13 @@ module.exports = (log = new Log()) => {
       // Send REST request.
       return requestClient().get(url)
       // Return good responses
-      .then(response => setGood(url))
+      .then(response => {
+        log.debug('scan response recieved', {
+          status: response && response.status,
+          headers: response && response.headers
+        });
+        return setGood(url);
+      })
       // Retry waitcodes or fail right away if we have a network issue
       .catch(error => {
         if (error.code === 'ENOTFOUND') return Promise.resolve(setBad(url));


### PR DESCRIPTION
## Context
We are using your awesome tool inside our `vip` [cli](https://github.com/Automattic/vip).

One of our users has issues when using the CLI on Windows machine. The proxy won't start as it can't detect any open port. Here is an extract from the debug log:

```
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if http://127.0.0.1:80 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if http://127.0.0.1:8000 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if http://127.0.0.1:8080 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if http://127.0.0.1:8888 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if http://127.0.0.1:8008 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if https://127.0.0.1:443 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if https://127.0.0.1:444 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if https://127.0.0.1:4433 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if https://127.0.0.1:4444 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> checking to see if https://127.0.0.1:4443 is ready. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> http://127.0.0.1:8000 is ready 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> http://127.0.0.1:8080 is ready 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> http://127.0.0.1:8888 is ready 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> http://127.0.0.1:8008 is ready 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> http://127.0.0.1:80 is ready 
[36mlando                 [39m [35m12:59:40[39m [90mVERBOSE[39m ==> scan completed. 
[36mlando                 [39m [35m12:59:40[39m [2mDEBUG[22m ==> scan results. url=http://127.0.0.1:80, status=true, color=green, url=http://127.0.0.1:8000, status=true, color=green, url=http://127.0.0.1:8080, status=true, color=green, url=http://127.0.0.1:8888, status=true, color=green, url=http://127.0.0.1:8008, status=true, color=green
```

followed by:
```
[41mERROR[49m ==> Lando could not detect an open port amongst: 80, 8000, 8080, 8888, 8008 
```

## What I tried

Checking the endpoints via `cron` seems to return expected result:
```
C:\Users\Pavel>docker run --network="host" --rm curlimages/curl -L -v http://localhost:80
*   Trying 127.0.0.1:80...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* connect to 127.0.0.1 port 80 failed: Connection refused
*   Trying ::1:80...
* connect to ::1 port 80 failed: Connection refused
* Failed to connect to localhost port 80 after 0 ms: Connection refused
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (7) Failed to connect to localhost port 80 after 0 ms: Connection refused
```

## Change

In this change, we are adding an extra logging line to get more insights into the issue, which would hopefully lead us to a fix suggestion. 
