### PR TITLE
Update Drupal 9 recipe to PHP 8.0

### DIFF
--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -33,9 +33,9 @@ Run the following commands to validate things are rolling as they should.
 cd drupal9
 lando ssh -s appserver -c "curl -L localhost" | grep "Drupal 9"
 
-# Should use 7.4 as the default php version
+# Should use 8.0 as the default php version
 cd drupal9
-lando php -v | grep "PHP 7.4"
+lando php -v | grep "PHP 8.0"
 
 # Should be running apache 2.4 by default
 cd drupal9

--- a/plugins/lando-recipes/recipes/drupal9/builder.js
+++ b/plugins/lando-recipes/recipes/drupal9/builder.js
@@ -16,7 +16,7 @@ module.exports = {
   config: {
     confSrc: __dirname,
     defaultFiles: {},
-    php: '7.4',
+    php: '8.1',
     drush: '^10',
   },
   builder: (parent, config) => class LandoDrupal9 extends parent {

--- a/plugins/lando-recipes/recipes/drupal9/builder.js
+++ b/plugins/lando-recipes/recipes/drupal9/builder.js
@@ -16,7 +16,7 @@ module.exports = {
   config: {
     confSrc: __dirname,
     defaultFiles: {},
-    php: '8.1',
+    php: '8.0',
     drush: '^10',
   },
   builder: (parent, config) => class LandoDrupal9 extends parent {


### PR DESCRIPTION
> **Recommendation**
> Use PHP version 8.0 or higher for current release versions of Drupal 9. Drupal 10 is planned to require PHP 8.

From the Drupal 9 [PHP requirements](https://www.drupal.org/docs/system-requirements/php-requirements).