### PR TITLE
Fix missing space in scanning for services message

### DIFF
--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -226,7 +226,7 @@ module.exports = (app, lando) => {
   // Scan urls
   app.events.on('post-start', 10, () => {
     // Message to let the user know it could take a bit
-    console.log('Scanning to determine which services are ready... Please standby...');
+    console.log('Scanning to determine which services are ready... Please stand by...');
     // Filter out any services where the scanner might be disabled
     return app.scanUrls(_.flatMap(getScannable(app), 'urls'), {max: 16}).then(urls => {
       // Get data about our scanned urls


### PR DESCRIPTION
"Standby" is a [noun](https://www.merriam-webster.com/dictionary/standby).

As a compound imperative verb it should be "stand by".