### PR TITLE
Ensure cert and ssh dir defensively

### DIFF
--- a/plugins/lando-core/index.js
+++ b/plugins/lando-core/index.js
@@ -61,9 +61,9 @@ module.exports = lando => {
   const caCert = path.join(caDir, `${caDomain}.pem`);
   const caKey = path.join(caDir, `${caDomain}.key`);
   const caProject = `landocasetupkenobi38ahsoka${lando.config.instance}`;
-  const sshDir = path.join(lando.config.home, '.ssh');
+  const sshDir = lando.config.home && path.join(lando.config.home, '.ssh');
   // Ensure some dirs exist before we start
-  _.forEach([caDir, sshDir], dir => mkdirp.sync(dir));
+  _.forEach([caDir, sshDir], dir => dir && mkdirp.sync(dir));
 
   // Make sure we have a host-exposed root ca if we don't already
   // NOTE: we don't run this on the caProject otherwise infinite loop happens!


### PR DESCRIPTION
Here is a PR for #134  @reynoldsalec 

When a user sets `home: ''` in `~/.lando/config.yml` Lando creates an empty `.ssh` folder in the working directory. This PR helps avoid this.

Fixes #134 