### PR TITLE
Update ip in order to support node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "glob": "^7.1.3",
     "inquirer": "^6.2.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
-    "ip": "^1.1.5",
+    "ip": "^1.1.8",
     "js-yaml": "^3.4.6",
     "jsonfile": "^2.4.0",
     "localtunnel": "^1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4235,10 +4235,10 @@ ip-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+ip@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
+  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
 is-absolute-url@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
More info here - https://github.com/indutny/node-ip/pull/114

Fixes:
```
TypeError: details.family.toLowerCase is not a function
```

Which shows up on node 18

(ref https://github.com/lando/cli/pull/147#issue-1235069213 from @pschoffer)