### PR TITLE
Support docker-compose v2

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -30,6 +30,8 @@ const loadPlugins = (app, lando) => Promise.resolve(app.plugins.registry)
   // Merge minotaur
   .each(result => _.merge(app, result));
 
+const defaultComposeSeparator = '_';
+
 /**
  * The class to instantiate a new App
  *
@@ -525,4 +527,14 @@ module.exports = class App {
     .then(() => this.events.emit('post-uninstall'))
     .then(() => this.log.info('uninstalled app.'));
   };
+
+  getServiceContainerId(service) {
+    const sep = this._lando && this._lando.config && this._lando.config.composeSeparator || defaultComposeSeparator;
+    return `${this.project}${sep}${service}${sep}1`;
+  }
+  getServiceFromContainerId(id) {
+    const sep = this._lando && this._lando.config && this._lando.config.composeSeparator || defaultComposeSeparator;
+    const regex = new RegExp(`${this.project}${sep}(.*)${sep}1`);
+    return id.replace(regex, '$1');
+  }
 };

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -56,6 +56,8 @@ const engineRunner = (config, command) => (argv, lando) => {
   const app = lando.cache.get(path.basename(config.composeCache));
   app.config = config;
   app.events = new AsyncEvents(lando.log);
+  const sep = lando.config.composeSeparator;
+  app.getServiceContainerId = service => `${app.project}${sep}${service}${sep}1`;
   // Load only what we need so we don't pay the appinit penalty
   const utils = require('./../plugins/lando-tooling/lib/utils');
   const buildTask = require('./../plugins/lando-tooling/lib/build');

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -38,6 +38,11 @@ const getMacProp = prop => shell.sh(['defaults', 'read', `${macOSBase}/Contents/
   .then(data => _.trim(data))
   .catch(() => null);
 
+
+const composeV1Separator = '_';
+const composeV2Separator = '-';
+
+
 /*
  * Creates a new Daemon instance.
  */
@@ -225,4 +230,16 @@ module.exports = class LandoDaemon {
         return Promise.resolve(versions);
     }
   };
+
+  getComposeSeparator() {
+    return new Promise(resolve => {
+      const semver = require('semver');
+      this.getVersions().then(versions => {
+        const isComposeV1 = semver.lt(versions.compose, '2.0.0');
+
+        const composeSeparator = isComposeV1 ? composeV1Separator : composeV2Separator;
+        resolve(composeSeparator);
+      });
+    });
+  }
 };

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -111,8 +111,16 @@ const bootstrapEngine = lando => {
     lando.config.instance
   );
   lando.utils = _.merge({}, require('./utils'), require('./config'));
+
+
+  const separatorPromise = new Promise(resolve => {
+    lando.engine.daemon.getComposeSeparator().then(sep => {
+      lando.config.composeSeparator = sep;
+      resolve();
+    });
+  });
   // Auto move and make executable any scripts
-  return lando.Promise.map(lando.config.plugins, plugin => {
+  const pluginPromise = lando.Promise.map(lando.config.plugins, plugin => {
     if (fs.existsSync(plugin.scripts)) {
       const confDir = path.join(lando.config.userConfRoot, 'scripts');
       const dest = lando.utils.moveConfig(plugin.scripts, confDir);
@@ -120,6 +128,8 @@ const bootstrapEngine = lando => {
       lando.log.debug('automoved scripts from %s to %s and set to mode 755', plugin.scripts, confDir);
     }
   });
+
+  return Promise.all([pluginPromise, separatorPromise]);
 };
 
 /*

--- a/plugins/lando-core/app.js
+++ b/plugins/lando-core/app.js
@@ -8,6 +8,7 @@ const toObject = require('./../../lib/utils').toObject;
 const utils = require('./lib/utils');
 const warnings = require('./lib/warnings');
 
+
 // Helper to get http ports
 const getHttpPorts = data => _.get(data, 'Config.Labels["io.lando.http-ports"]', '80,443').split(',');
 const getHttpsPorts = data => _.get(data, 'Config.Labels["io.lando.https-ports"]', '443').split(',');
@@ -71,7 +72,7 @@ module.exports = (app, lando) => {
     app.log.verbose('refreshing certificates...', buildServices);
     app.events.on('post-start', 9999, () => lando.Promise.each(buildServices, service => {
       return app.engine.run({
-        id: `${app.project}_${service}_1`,
+        id: app.getServiceContainerId(service),
         cmd: 'mkdir -p /certs && /helpers/refresh-certs.sh > /certs/refresh.log',
         compose: app.compose,
         project: app.project,
@@ -94,7 +95,7 @@ module.exports = (app, lando) => {
       app.log.verbose('perm sweeping flagged non-root containers ...', app.nonRoot);
       app.events.on('post-start', 1, () => lando.Promise.each(app.nonRoot, service => {
         return app.engine.run({
-          id: `${app.project}_${service}_1`,
+          id: app.getServiceContainerId(service),
           cmd: '/helpers/user-perms.sh --silent',
           compose: app.compose,
           project: app.project,
@@ -171,7 +172,7 @@ module.exports = (app, lando) => {
     // Map to a retry of the healthcheck command
     .map(info => lando.Promise.retry(() => {
       return app.engine.run({
-        id: `${app.project}_${info.service}_1`,
+        id: app.getServiceContainerId(info.service),
         cmd: info.healthcheck,
         compose: app.compose,
         project: app.project,

--- a/plugins/lando-events/app.js
+++ b/plugins/lando-events/app.js
@@ -22,7 +22,7 @@ module.exports = (app, lando) => {
               opts: {
                 mode: 'attach',
                 user: 'root',
-                services: [container.split('_')[1]],
+                services: [app.getServiceFromContainerId(container)],
               },
             });
           });

--- a/plugins/lando-proxy/index.js
+++ b/plugins/lando-proxy/index.js
@@ -32,12 +32,12 @@ const defaultConfig = {
   proxyPassThru: true,
 };
 
+
 module.exports = lando => {
   // Add in some computed config eg things after our config has been settled
   lando.events.on('post-bootstrap-config', ({config}) => {
     lando.log.verbose('building proxy config...');
     // Set some non dependent things
-    config.proxyContainer = `${lando.config.proxyName}_proxy_1`;
     config.proxyCurrentPorts = {http: config.proxyHttpPort, https: config.proxyHttpsPort};
     config.proxyDir = path.join(lando.config.userConfRoot, 'proxy');
     config.proxyHttpPorts = _.flatten([config.proxyHttpPort, config.proxyHttpFallbacks]);
@@ -48,6 +48,11 @@ module.exports = lando => {
     config.proxyScanHttps = utils.ports2Urls(config.proxyHttpsPorts, true, config.proxyBindAddress);
     // And dependent things
     config.proxyConfigDir = path.join(config.proxyDir, 'config');
+  });
+
+  lando.events.on('post-bootstrap-engine', () => {
+    const sep = lando.config.composeSeparator;
+    lando.config.proxyContainer = `${lando.config.proxyName}${sep}proxy${sep}1`;
   });
 
   // Return config defaults to rebase

--- a/plugins/lando-services/lib/utils.js
+++ b/plugins/lando-services/lib/utils.js
@@ -49,7 +49,7 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
       if (!_.isEmpty(_.get(app, `config.services.${service}.${section}`, []))) {
         // Run each command
         _.forEach(app.config.services[service][section], cmd => {
-          const container = `${app.project}_${service}_1`;
+          const container = app.getServiceContainerId(service);
           build.push({
             id: container,
             cmd: ['/bin/sh', '-c', _.isArray(cmd) ? cmd.join(' ') : cmd],
@@ -79,7 +79,7 @@ exports.filterBuildSteps = (services, app, rootSteps = [], buildSteps= [], prest
           mode: 'attach',
           prestart,
           user: 'root',
-          services: [container.split('_')[1]],
+          services: [app.getServiceFromContainerId(container)],
         },
       });
     });

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -110,7 +110,7 @@ const parseCommand = (cmd, service) => ({
  * Helper to build commands
  */
 exports.buildCommand = (app, command, service, user, env = {}, dir = undefined) => ({
-  id: `${app.project}_${service}_1`,
+  id: app.getServiceContainerId(service),
   compose: app.compose,
   project: app.project,
   cmd: command,


### PR DESCRIPTION
Docker compose v2 switched from using _ to - as a seperator in container ids.

In lando there are several places where _ was hardcoded which made it incompatible with docker-compose v2.

This change seems to address most of those. I tested this on our local dev-env powered by lando and all seems to work after this change.