### PR TITLE
ci: Fix deprecated `set-output` command

### DIFF
--- a/.github/workflows/build-util-images.yml
+++ b/.github/workflows/build-util-images.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set tag suffix
         id: pr
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "::set-output name=TAG_SUFFIX::-edge"
+        run: echo "TAG_SUFFIX=-edge" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/pr-core-tests.yml
+++ b/.github/workflows/pr-core-tests.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache

--- a/.github/workflows/pr-db-tools-tests.yml
+++ b/.github/workflows/pr-db-tools-tests.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache

--- a/.github/workflows/pr-django-tests.yml
+++ b/.github/workflows/pr-django-tests.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache

--- a/.github/workflows/pr-plugins-installed.yml
+++ b/.github/workflows/pr-plugins-installed.yml
@@ -59,7 +59,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v2
         id: yarn-cache


### PR DESCRIPTION
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Basically, this PR replaces

```sh
echo "::set-output name={name}::{value}"
```

with 

```sh
echo "{name}={value}" >> $GITHUB_OUTPUT
```

as suggested in the [official announcement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples)
